### PR TITLE
ci: Fix build/test pipeline on merge

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,18 +50,6 @@ jobs:
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
 
-      - name: Run black formatter check
-        run: black --check confidence
-
-      - name: Run flake8 formatter check
-        run: flake8 confidence
- 
-      - name: Run type linter check
-        run: mypy confidence
-
-      - name: Run tests with pytest
-        run: pytest
-
       - name: Install pypa/build
         run: >-
           python -m                                           
@@ -80,7 +68,19 @@ jobs:
           --sdist                                             
           --wheel                                             
           --outdir dist/                                      
-          .                                                   
+          .
+
+      - name: Run black formatter check
+        run: black --check confidence
+
+      - name: Run flake8 formatter check
+        run: flake8 confidence
+ 
+      - name: Run type linter check
+        run: mypy confidence
+
+      - name: Run tests with pytest
+        run: pytest                                                
 
       - name: Publish a Python distribution to Test-PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
[Recent changes](https://github.com/spotify/confidence-openfeature-provider-python/pull/34/files#diff-38083b7907f98163579dd32304b5e2dd732607173f1b4ebabc88b93ee710a874R2) relies on `version.py` that is generated at build time. The idea is to build the project before running any linter. 

Error in CI:
```
Run mypy confidence
confidence/__init__.py:2: error: Cannot find implementation or library stub for module named "confidence._version"  [import]
confidence/__init__.py:2: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
Found 1 error in 1 file (checked 3 source files)
Error: Process completed with exit code 1.
```