### PR TITLE
ci: enable mypy in pre-merge and fix issues

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -55,6 +55,9 @@ jobs:
 
       - name: Run flake8 formatter check
         run: flake8 confidence
+ 
+      - name: Run type linter check
+        run: mypy confidence
 
       - name: Run tests with pytest
         run: pytest

--- a/confidence/__init__.py
+++ b/confidence/__init__.py
@@ -3,4 +3,4 @@ try:
     from ._version import version_tuple
 except ImportError:
     __version__ = "unknown version"
-    version_tuple = (0, 0, "unknown version")
+    version_tuple = (0, 0, 0, "unknown version")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.31.0
-openfeature-sdk==0.4.1
+openfeature-sdk==0.3.1


### PR DESCRIPTION
Previously we had this error:

```
> mypy confidence
confidence/__init__.py:6: error: Incompatible types in assignment (expression has type "tuple[int, int, str]", variable has type "tuple[int, int, int, str]")  [assignment]
Found 1 error in 1 file (checked 4 source files)
```