### PR TITLE
chore: enable mypy in pull-request workflow

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -55,6 +55,9 @@ jobs:
 
       - name: Run flake8 formatter check
         run: flake8 confidence
+ 
+      - name: Run type linter check
+        run: mypy confidence
 
       - name: Run tests with pytest
         run: pytest

--- a/confidence/__init__.py
+++ b/confidence/__init__.py
@@ -3,4 +3,4 @@ try:
     from ._version import version_tuple
 except ImportError:
     __version__ = "unknown version"
-    version_tuple = (0, 0, "unknown version")
+    version_tuple = (0, 0, 0, "unknown version")


### PR DESCRIPTION
`mypy` should run as a PR requirement. Before it can be merged.