### PR TITLE
fix: fixes to enable mypy in premerge

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -75,6 +75,9 @@ jobs:
 
       - name: Run flake8 formatter check
         run: flake8 confidence
+ 
+      - name: Run type linter check
+        run: mypy confidence
 
       - name: Run type linter check
         run: mypy confidence

--- a/confidence/__init__.py
+++ b/confidence/__init__.py
@@ -3,4 +3,4 @@ try:
     from ._version import version_tuple
 except ImportError:
     __version__ = "unknown version"
-    version_tuple = (0, 0, "unknown version")
+    version_tuple = (0, 0, 0, "unknown version")

--- a/confidence/provider.py
+++ b/confidence/provider.py
@@ -11,7 +11,7 @@ from openfeature.exception import (
     ParseError,
     TypeMismatchError,
 )
-from openfeature.flag_evaluation import FlagEvaluationDetails
+from openfeature.flag_evaluation import FlagResolutionDetails
 from openfeature.flag_evaluation import Reason
 from openfeature.api import Hook
 from openfeature.provider.metadata import Metadata
@@ -83,7 +83,7 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
         flag_key: str,
         default_value: bool,
         evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[bool]:
+    ) -> FlagResolutionDetails[bool]:
         return self._evaluate(flag_key, bool, default_value, evaluation_context)
 
     def resolve_float_details(
@@ -91,7 +91,7 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
         flag_key: str,
         default_value: float,
         evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[float]:
+    ) -> FlagResolutionDetails[float]:
         return self._evaluate(flag_key, float, default_value, evaluation_context)
 
     def resolve_integer_details(
@@ -99,7 +99,7 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
         flag_key: str,
         default_value: int,
         evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[int]:
+    ) -> FlagResolutionDetails[int]:
         return self._evaluate(flag_key, int, default_value, evaluation_context)
 
     def resolve_string_details(
@@ -107,15 +107,15 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
         flag_key: str,
         default_value: str,
         evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[str]:
+    ) -> FlagResolutionDetails[str]:
         return self._evaluate(flag_key, str, default_value, evaluation_context)
 
     def resolve_object_details(
         self,
         flag_key: str,
-        default_value: Object,
+        default_value: Union[Object, List[Primitive]],
         evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[dict]:
+    ) -> FlagResolutionDetails[Union[Object, List[Primitive]]]:
         return self._evaluate(flag_key, Object, default_value, evaluation_context)
 
     #
@@ -128,7 +128,7 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
         value_type: Type[FieldType],
         default_value: FieldType,
         evaluation_context: Optional[EvaluationContext] = None,
-    ) -> FlagEvaluationDetails[Any]:
+    ) -> FlagResolutionDetails[Any]:
         if evaluation_context is None:
             evaluation_context = EvaluationContext()
 
@@ -146,7 +146,7 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
 
         result = self._resolve(FlagName(flag_id), context)
         if result.variant is None or len(str(result.value)) == 0:
-            return FlagEvaluationDetails(flag_key, default_value, reason=Reason.DEFAULT)
+            return FlagResolutionDetails(value=default_value, reason=Reason.DEFAULT)
 
         variant_name = VariantName.parse(result.variant)
 
@@ -154,8 +154,8 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
         if value is None:
             value = default_value
 
-        return FlagEvaluationDetails(
-            flag_key, value, variant_name.variant, reason=Reason.TARGETING_MATCH
+        return FlagResolutionDetails(
+            value=value, variant=variant_name.variant, reason=Reason.TARGETING_MATCH
         )
 
     def _resolve(self, flag_name: FlagName, context: Dict[str, str]) -> ResolveResult:

--- a/confidence/provider.py
+++ b/confidence/provider.py
@@ -146,7 +146,11 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
 
         result = self._resolve(FlagName(flag_id), context)
         if result.variant is None or len(str(result.value)) == 0:
-            return FlagResolutionDetails(value=default_value, reason=Reason.DEFAULT)
+            return FlagResolutionDetails(
+                value=default_value,
+                reason=Reason.DEFAULT,
+                flag_metadata={"flag_key": flag_key},
+            )
 
         variant_name = VariantName.parse(result.variant)
 
@@ -155,7 +159,10 @@ class ConfidenceOpenFeatureProvider(AbstractProvider):  # type: ignore
             value = default_value
 
         return FlagResolutionDetails(
-            value=value, variant=variant_name.variant, reason=Reason.TARGETING_MATCH
+            value=value,
+            variant=variant_name.variant,
+            reason=Reason.TARGETING_MATCH,
+            flag_metadata={"flag_key": flag_key},
         )
 
     def _resolve(self, flag_name: FlagName, context: Dict[str, str]) -> ResolveResult:

--- a/tests/test_names.py
+++ b/tests/test_names.py
@@ -4,7 +4,6 @@ from confidence.names import FlagName, VariantName
 
 
 class NamesTest(unittest.TestCase):
-
     def test_flag_name_valid(self):
         self.assertEqual(str(FlagName("myFlag")), "flags/myFlag")
 
@@ -27,5 +26,5 @@ class NamesTest(unittest.TestCase):
         self.assertRaises(ValueError, VariantName.parse, "variant-1")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -28,7 +28,9 @@ class TestMyProvider(unittest.TestCase):
                 evaluation_context=ctx,
             )
 
-            self.assertEqual(result.flag_key, "python-flag-1.string-key")
+            self.assertEqual(
+                result.flag_metadata["flag_key"], "python-flag-1.string-key"
+            )
             self.assertEqual(result.value, "outer-string")
             self.assertEqual(result.variant, "enabled")
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
@@ -47,7 +49,9 @@ class TestMyProvider(unittest.TestCase):
             )
 
             self.assertEqual(result.reason, Reason.DEFAULT)
-            self.assertEqual(result.flag_key, "some-flag-that-doesnt-exist")
+            self.assertEqual(
+                result.flag_metadata["flag_key"], "some-flag-that-doesnt-exist"
+            )
             self.assertEqual(result.value, "yellow")
             self.assertIsNone(result.variant)
 
@@ -94,7 +98,7 @@ class TestMyProvider(unittest.TestCase):
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
-            self.assertEqual(result.flag_key, "python-flag-1")
+            self.assertEqual(result.flag_metadata["flag_key"], "python-flag-1")
             self.assertEqual(
                 result.value,
                 {
@@ -122,7 +126,9 @@ class TestMyProvider(unittest.TestCase):
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
-            self.assertEqual(result.flag_key, "python-flag-1.struct-key")
+            self.assertEqual(
+                result.flag_metadata["flag_key"], "python-flag-1.struct-key"
+            )
             self.assertEqual(result.value, {"string-key": "inner-string"})
 
     def test_resolve_integer_details(self):
@@ -141,7 +147,7 @@ class TestMyProvider(unittest.TestCase):
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
-            self.assertEqual(result.flag_key, "python-flag-1.int-key")
+            self.assertEqual(result.flag_metadata["flag_key"], "python-flag-1.int-key")
             self.assertEqual(result.value, 42)
 
     def test_resolve_boolean_details(self):
@@ -160,7 +166,7 @@ class TestMyProvider(unittest.TestCase):
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
-            self.assertEqual(result.flag_key, "python-flag-1.enabled")
+            self.assertEqual(result.flag_metadata["flag_key"], "python-flag-1.enabled")
             self.assertEqual(result.value, True)
 
     def test_resolve_float_details(self):
@@ -179,7 +185,9 @@ class TestMyProvider(unittest.TestCase):
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
-            self.assertEqual(result.flag_key, "python-flag-1.double-key")
+            self.assertEqual(
+                result.flag_metadata["flag_key"], "python-flag-1.double-key"
+            )
             self.assertEqual(result.value, 42.42)
 
     def test_resolve_without_targeting_key(self):

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -7,6 +7,7 @@ from confidence.provider import Region
 from confidence.provider import Reason
 from confidence import provider
 
+
 class TestMyProvider(unittest.TestCase):
     def setUp(self):
         self.provider = ConfidenceOpenFeatureProvider(client_secret="test")
@@ -88,18 +89,22 @@ class TestMyProvider(unittest.TestCase):
             )
             result = self.provider.resolve_object_details(
                 flag_key="python-flag-1",
-                default_value={'key': 'value'},
+                default_value={"key": "value"},
                 evaluation_context=ctx,
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
             self.assertEqual(result.flag_key, "python-flag-1")
-            self.assertEqual(result.value, {'double-key': 42.42,
-                                            'enabled': True,
-                                            'int-key': 42,
-                                            'string-key': 'outer-string',
-                                            'struct-key': {'string-key': 'inner-string'}}
-                             )
+            self.assertEqual(
+                result.value,
+                {
+                    "double-key": 42.42,
+                    "enabled": True,
+                    "int-key": 42,
+                    "string-key": "outer-string",
+                    "struct-key": {"string-key": "inner-string"},
+                },
+            )
 
     def test_resolve_struct_details(self):
         ctx = EvaluationContext(
@@ -112,13 +117,13 @@ class TestMyProvider(unittest.TestCase):
             )
             result = self.provider.resolve_object_details(
                 flag_key="python-flag-1.struct-key",
-                default_value={'key': 'value'},
+                default_value={"key": "value"},
                 evaluation_context=ctx,
             )
 
             self.assertEqual(result.reason, Reason.TARGETING_MATCH)
             self.assertEqual(result.flag_key, "python-flag-1.struct-key")
-            self.assertEqual(result.value, {'string-key': 'inner-string'})
+            self.assertEqual(result.value, {"string-key": "inner-string"})
 
     def test_resolve_integer_details(self):
         ctx = EvaluationContext(
@@ -202,9 +207,7 @@ class TestMyProvider(unittest.TestCase):
             )
 
     def test_no_segment_match(self):
-        ctx = EvaluationContext(
-            attributes={"connection": "wifi"}
-        )
+        ctx = EvaluationContext(attributes={"connection": "wifi"})
         with requests_mock.Mocker() as mock:
             mock.post(
                 "https://resolver.eu.confidence.dev/v1/flags:resolve",

--- a/tests/test_provider_parametrized.py
+++ b/tests/test_provider_parametrized.py
@@ -6,12 +6,7 @@ from confidence.provider import ConfidenceOpenFeatureProvider
 from tests.test_provider import SUCCESSFUL_FLAG_RESOLVE
 
 
-@pytest.mark.parametrize(
-    "apply_on_resolve",
-    (
-            (True, False)
-    )
-)
+@pytest.mark.parametrize("apply_on_resolve", ((True, False)))
 def test_apply_configurable(apply_on_resolve):
     ctx = EvaluationContext(targeting_key="meh")
     apply_provider = ConfidenceOpenFeatureProvider(


### PR DESCRIPTION
The main goal of this PR is to enable `mypy` to run type checker in the PR workflow. In order to do that we had to update the provider code to be correctly implementing the `AbstractProvider` from the the OF SDK.